### PR TITLE
Removed import and definition of the AsyncHyperbandScheduler in the Ax+Tune example

### DIFF
--- a/python/ray/tune/examples/ax_example.py
+++ b/python/ray/tune/examples/ax_example.py
@@ -10,7 +10,6 @@ import numpy as np
 
 import ray
 from ray.tune import run
-from ray.tune.schedulers import AsyncHyperBandScheduler
 from ray.tune.suggest.ax import AxSearch
 
 
@@ -112,5 +111,4 @@ if __name__ == "__main__":
         outcome_constraints=["l2norm <= 1.25"],  # Optional.
     )
     algo = AxSearch(client, max_concurrent=4)
-    scheduler = AsyncHyperBandScheduler(metric="hartmann6", mode="max")
     run(easy_objective, name="ax", search_alg=algo, **config)


### PR DESCRIPTION
The AsyncHyperBand scheduler does not seem to be in use. Removing it will add clarity in this example script.

## Why are these changes needed?

Make the example simpler to read, removing unnecessary call to a Tune scheduler.

## Related issue number

## Checks

- [] I've run `scripts/format.sh` to lint the changes in this PR.

